### PR TITLE
Fixed issue with leftover number after operation.

### DIFF
--- a/Assets/App.cs
+++ b/Assets/App.cs
@@ -175,7 +175,9 @@ public class App : MonoBehaviour
 
         if (result.HasValue)
         {
+            previousOperation = menuCreator.m_MenuTitle.text + " =";
             numbers[0] = result.Value.ToString();
+            numbers[1] = "";
         } else
         {
             previousOperation = menuCreator.m_MenuTitle.text;


### PR DESCRIPTION
There was a leftover number on the display after executing an operation. I have fixed it and added also the previous operation on top displayed.